### PR TITLE
logic to tell user to highlight text

### DIFF
--- a/chrome-extension/highlight.js
+++ b/chrome-extension/highlight.js
@@ -1,9 +1,9 @@
 chrome.tabs.executeScript( {
   code: "window.getSelection().toString();"
 }, function(selection) {
-  if(selection){
+  if(selection && selection[0]){ //only calls ajax if something is highlighted and highlighted text isn't empty
     document.getElementById("highlighted").innerHTML = "Related to: " + selection[0];
-
+    $("#ajax").append("<h4>Loading articles...</h4>");
     $.ajax({
       type: "POST",
       url: 'http://localhost:8000/app/lookup',

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -34,11 +34,11 @@
       </select>-->
     </div>
     <div id="highlighted">
-      <!--this is where the highlighted text shows up-->
+      <p style="text-align: center;">Highlight some text to use the extension</p>
+      <!--this is where the highlighted text shows up and replaces the above sentence-->
     </div>
     <br>
     <div id="ajax">
-      <h4>Loading articles...</h4>
       <!--this is where the articles show up-->
     </div>
   </body>


### PR DESCRIPTION
Now instead of just showing "related to" with no explanation, the user sees "highlight some text to use the extension" and the ajax call isn't made on an empty string if they haven't highlighted anything